### PR TITLE
feat(tool/errmon): Add (*Event).GetID() method

### DIFF
--- a/tool/experimental/errmon/types/event.go
+++ b/tool/experimental/errmon/types/event.go
@@ -46,6 +46,14 @@ type Event struct {
 	Goroutines []Goroutine
 }
 
+// GetID is a safe accessor of an event ID, it returns an empty ID if Event is nil.
+func (ev *Event) GetID() EventID {
+	if ev == nil {
+		return EventID("")
+	}
+	return ev.ID
+}
+
 // Goroutine is a full collection of data collected on a specific goroutine.
 type Goroutine = gostackparse.Goroutine
 

--- a/tool/experimental/errmon/types/event_test.go
+++ b/tool/experimental/errmon/types/event_test.go
@@ -1,0 +1,9 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestEventGetID(t *testing.T) {
+	(*Event)(nil).GetID() // should not panic
+}


### PR DESCRIPTION
This method is a syntax sugar for `defer func` blocks, in the end-user code.