### PR TITLE
feat(errmon.Event): Add method AsError

### DIFF
--- a/tool/experimental/errmon/types/errors.go
+++ b/tool/experimental/errmon/types/errors.go
@@ -1,0 +1,39 @@
+package types
+
+import (
+	"fmt"
+)
+
+// ErrPanic is a wrapper of an Event which implements `error` in case if
+// the Event conveys a panic event.
+type ErrPanic struct {
+	Event *Event
+}
+
+// Error implements interface `error`.
+func (err ErrPanic) Error() string {
+	return fmt.Sprintf(`[event ID: '%s'][goroutine %d] got a panic: %v
+stack trace:
+%s`,
+		err.Event.ID,
+		err.Event.CurrentGoroutineID,
+		err.Event.PanicValue,
+		err.Event.StackTrace,
+	)
+}
+
+// ErrError is a wrapper of an Event which implements `error` in case if
+// the Event conveys an error event.
+type ErrError struct {
+	Event *Event
+}
+
+// Error implements interface `error`.
+func (err ErrError) Error() string {
+	return fmt.Sprintf("[event ID: '%s'] %v", err.Event.ID, err.Unwrap())
+}
+
+// Unwrap implements go1.13 errors unwrapping.
+func (err ErrError) Unwrap() error {
+	return err.Event.Exception.Error
+}

--- a/tool/experimental/errmon/types/event.go
+++ b/tool/experimental/errmon/types/event.go
@@ -54,6 +54,31 @@ func (ev *Event) GetID() EventID {
 	return ev.ID
 }
 
+// AsError is a syntax-sugar function which returns a non-nil value only
+// if there was an error or a panic observed.
+//
+// For example this block:
+//
+//	defer func() {
+//		ev := errmon.ObserveRecoverCtx(ctx, recover())
+//		if ev != nil {
+//			err = fmt.Errorf("got panic: %v (event ID: '%s')", ev.PanicValue, ev.ID)
+//		}
+//	}()
+//
+// Could be replaced with simpler:
+//
+//	defer func() { err = errmon.ObserveRecoverCtx(ctx, recover()).AsError() }()
+func (ev *Event) AsError() error {
+	if ev == nil {
+		return nil
+	}
+	if ev.IsPanic {
+		return ErrPanic{Event: ev}
+	}
+	return ErrError{Event: ev}
+}
+
 // Goroutine is a full collection of data collected on a specific goroutine.
 type Goroutine = gostackparse.Goroutine
 

--- a/tool/experimental/errmon/types/event_test.go
+++ b/tool/experimental/errmon/types/event_test.go
@@ -1,9 +1,64 @@
 package types
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestEventGetID(t *testing.T) {
 	(*Event)(nil).GetID() // should not panic
+}
+
+func TestEventError(t *testing.T) {
+	ev := &Event{
+		ID: "1",
+		Exception: Exception{
+			StackTrace: []runtime.Frame{
+				{
+					Function: "func1()",
+					File:     "file1.go",
+					Line:     123,
+				},
+				{
+					Function: "func2()",
+					File:     "file2.go",
+					Line:     234,
+				},
+			},
+		},
+		CurrentGoroutineID: 2,
+		Goroutines: []Goroutine{
+			{
+				ID: 2,
+			},
+			{
+				ID: 3,
+			},
+		},
+	}
+
+	t.Run("panic", func(t *testing.T) {
+		ev.Exception.Error = nil
+		ev.Exception.IsPanic = true
+		ev.Exception.PanicValue = "unit-test"
+		err := ev.AsError()
+		require.ErrorAs(t, err, &ErrPanic{})
+		require.Equal(t, `[event ID: '1'][goroutine 2] got a panic: unit-test
+stack trace:
+1. file1.go:123: func1()
+2. file2.go:234: func2()
+`, err.Error())
+	})
+
+	t.Run("error", func(t *testing.T) {
+		ev.Exception.Error = fmt.Errorf("unit-test")
+		ev.Exception.IsPanic = false
+		ev.Exception.PanicValue = nil
+		err := ev.AsError()
+		require.ErrorAs(t, err, &ErrError{})
+		require.Equal(t, "[event ID: '1'] unit-test", err.Error())
+	})
 }

--- a/tool/experimental/errmon/types/exception.go
+++ b/tool/experimental/errmon/types/exception.go
@@ -12,15 +12,11 @@
 
 package types
 
-import (
-	"runtime"
-)
-
 // Exception is the immediate information about what gone wrong.
 type Exception struct {
 	IsPanic    bool
 	PanicValue any
 	Error      error
 
-	StackTrace []runtime.Frame
+	StackTrace StackTrace
 }

--- a/tool/experimental/errmon/types/stack_trace.go
+++ b/tool/experimental/errmon/types/stack_trace.go
@@ -1,0 +1,19 @@
+package types
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// StackTrace is a goroutine execution frames stack trace.
+type StackTrace []runtime.Frame
+
+// String implements fmt.Stringer.
+func (s StackTrace) String() string {
+	var result strings.Builder
+	for idx, frame := range s {
+		result.WriteString(fmt.Sprintf("%d. %s:%d: %s\n", idx+1, frame.File, frame.Line, frame.Function))
+	}
+	return result.String()
+}


### PR DESCRIPTION
This method is a syntax-sugar, which makes automatic interception of panics handier. Now instead of:

```go
defer func() {
	ev := errmon.ObserveRecoverCtx(ctx, recover())
	if ev != nil {
		err = fmt.Errorf("got panic: %v (event ID: '%s')", ev.PanicValue, ev.ID)
	}
}()
```
it will be enough to just write:

```go
defer func() { err = errmon.ObserveRecoverCtx(ctx, recover()).AsError() }()
```

---

An example of how panic error message is formatted:
```
[event ID: '1'][goroutine 2] got a panic: unit-test
stack trace:
1. file1.go:123: func1()
2. file2.go:234: func2()
```

---

ITS: https://github.com/facebookincubator/go-belt/issues/3