### PR TITLE
CI: Add license header checker

### DIFF
--- a/.github/scripts/check_license_header.sh
+++ b/.github/scripts/check_license_header.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+FILE_PATH="$1"; shift
+exec grep -E '(Meta Platforms, Inc. and affiliates)|(Facebook, Inc(\.|,)? and its affiliates)|([0-9]{4}-present(\.|,)? Facebook)|([0-9]{4}(\.|,)? Facebook)' "$FILE_PATH" >/dev/null

--- a/.github/scripts/check_license_headers.sh
+++ b/.github/scripts/check_license_headers.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+SCRIPT_PATH="$(dirname "$0")"
+find . -type f -name "*.go" \( -exec "$SCRIPT_PATH"/check_license_header.sh {} \; -o -print \) | awk 'BEGIN{count=0} {count++; print "Error: File "$0" is missing a correct license header"} END{if(count != 0){ exit 1 }}' >&2

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,14 @@
+name: "License header checker"
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: ".github/scripts/check_license_headers.sh"

--- a/tool/experimental/errmon/types/errors.go
+++ b/tool/experimental/errmon/types/errors.go
@@ -1,3 +1,15 @@
+// Copyright 2022 Meta Platforms, Inc. and affiliates.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 package types
 
 import (

--- a/tool/experimental/errmon/types/stack_trace.go
+++ b/tool/experimental/errmon/types/stack_trace.go
@@ -1,3 +1,15 @@
+// Copyright 2022 Meta Platforms, Inc. and affiliates.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 package types
 
 import (


### PR DESCRIPTION
# Test Plan

### Successfully finds missing headers
![Screenshot from 2022-12-12 14-07-20](https://user-images.githubusercontent.com/2349376/207065808-f552cb9a-5c2b-4b1e-8013-e8ed702c306b.png)

![Screenshot from 2022-12-12 14-08-24](https://user-images.githubusercontent.com/2349376/207065999-e5b8cbed-9706-4bd9-8892-ad010e47b717.png)


### Reports OK when headers are fine
![Screenshot from 2022-12-12 14-07-29](https://user-images.githubusercontent.com/2349376/207065873-decd6aaa-9889-444d-b0b2-88718cdfed7f.png)
