### PR TITLE
bugfix(field): Do not skip fields accidentally

### DIFF
--- a/pkg/field/abstract_fields.go
+++ b/pkg/field/abstract_fields.go
@@ -42,10 +42,9 @@ type Slice[T AbstractFields] []T
 // Len implements AbstractFields.
 func (s Slice[T]) Len() int {
 	count := 0
-	s.ForEachField(func(f *Field) bool {
-		count++
-		return true
-	})
+	for _, items := range s {
+		count += items.Len()
+	}
 	return count
 }
 


### PR DESCRIPTION
Field calculation was wrong, because of that the amount of fields printed through optimized loggers (like zap) sometimes was lower. This is because these loggers needs the amount of field to manage memory smarter.

This PR includes an unit-test which reveals the error, and the fix.