### PR TITLE
Parse errors

### DIFF
--- a/pkg/valuesparser/values_parser.go
+++ b/pkg/valuesparser/values_parser.go
@@ -40,15 +40,23 @@ func (p *AnySlice) ForEachField(callback func(f *field.Field) bool) bool {
 			idx++
 			continue
 		}
-		v := reflect.Indirect(reflect.ValueOf(value))
-		if forEachFielder, ok := v.Interface().(field.ForEachFieldser); ok {
-			if !forEachFielder.ForEachField(callback) {
+
+		switch v := value.(type) {
+		case field.ForEachFieldser:
+			if !v.ForEachField(callback) {
 				return false
 			}
 			idx++
 			continue
+		case error:
+			callback(&field.Field{
+				Key:        "error",
+				Value:      v,
+				Properties: nil,
+			})
 		}
 
+		v := reflect.Indirect(reflect.ValueOf(value))
 		switch v.Kind() {
 		case reflect.Map:
 			r := ParseMapValue(v, callback)

--- a/pkg/valuesparser/values_parser_test.go
+++ b/pkg/valuesparser/values_parser_test.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Meta Platforms, Inc. and affiliates.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package valuesparser
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/facebookincubator/go-belt/pkg/field"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnySliceError(t *testing.T) {
+	err := fmt.Errorf("unit-test")
+	s := AnySlice{err}
+	count := 0
+	r := s.ForEachField(func(f *field.Field) bool {
+		count++
+		assert.Equal(t, f.Key, "error")
+		return true
+	})
+	assert.True(t, r)
+	assert.Equal(t, count, 1)
+
+	var buf bytes.Buffer
+	s.WriteUnparsed(&buf)
+	assert.Equal(t, "", buf.String())
+}

--- a/tool/logger/adapter/printfer_backend_logger.go
+++ b/tool/logger/adapter/printfer_backend_logger.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/facebookincubator/go-belt/pkg/field"
 	"github.com/facebookincubator/go-belt/tool/logger/types"
 )
 
@@ -91,6 +92,15 @@ func unstructuredMessageFromEntry(entry *types.Entry) string {
 		result.WriteString("] ")
 	}
 	result.WriteString(msg)
+
+	entry.Fields.ForEachField(func(f *field.Field) bool {
+		switch v := f.Value.(type) {
+		case error:
+			result.WriteString(" error:")
+			result.WriteString(v.Error())
+		}
+		return true
+	})
 
 	return result.String()
 }

--- a/tool/logger/implementation/zap/logger_unsafe.go
+++ b/tool/logger/implementation/zap/logger_unsafe.go
@@ -52,6 +52,9 @@ func fieldsToZap(length int, forEachField func(callback func(f *field.Field) boo
 		case float64:
 			zapField.Type = zapcore.Float64Type
 			zapField.Integer = int64(math.Float64bits(value))
+		case error:
+			zapField.Type = zapcore.ErrorType
+			zapField.Interface = f.Value
 		default:
 			zapField.Type = zapcore.ReflectType
 			zapField.Interface = f.Value

--- a/tool/logger/tests/implementation_test.go
+++ b/tool/logger/tests/implementation_test.go
@@ -14,6 +14,7 @@ package tests
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"net/url"
 	"strings"
@@ -109,7 +110,14 @@ func TestImplementations(t *testing.T) {
 		l.Logger.Errorf("unit-test")
 		l.Logger.Flush()
 		if !strings.Contains(l.Output.String(), "unit-test") {
-			t.Fatalf("logger %s did not print an error", l.Name)
+			t.Fatalf("logger %s did not print an error using Errorf", l.Name)
+		}
+		l.Output.Reset()
+
+		l.Logger.Error(fmt.Errorf("unit-test"))
+		l.Logger.Flush()
+		if !strings.Contains(l.Output.String(), "unit-test") {
+			t.Fatalf("logger %s did not print an error using Error", l.Name)
 		}
 		l.Output.Reset()
 	}


### PR DESCRIPTION
# Bug
If we do
```
err := someFunc()
logger.FromCtx(ctx).Panic(err)
```

Then we get empty message.

# Fix

Here I force it to interpret interface `error` as a value for field `error`. So not instead of:
```
{"level":"panic","ts":1684282789.2759905,"caller":"afasd/main.go:100","msg":"","trace_id":["AFAS:006383fc-28ec-44f2-9804-ba23e6087b55"],"pid":754,"uid":0,"username":"root","hostname":"7e83a1a9ccaa","immune/logentryfingerprint":"49119b7cac45a2c482eb22bb74767cf3e81e2d84"}
```
we get:
```
{"level":"panic","ts":1684282506.894337,"caller":"afasd/main.go:100","msg":"","trace_id":["AFAS:39aa8272-7ad0-4dd3-99b9-3009795f0021"],"pid":793,"uid":0,"username":"root","hostname":"7e83a1a9ccaa","error":"sdf","immune/logentryfingerprint":"49119b7cac45a2c482eb22bb74767cf3e81e2d84"}
```
(see `"error":"sdf"`)