### PR TITLE
bugfix(zap): Re-set the Caller

### DIFF
--- a/tool/logger/implementation/zap/logger.go
+++ b/tool/logger/implementation/zap/logger.go
@@ -184,6 +184,7 @@ func (l *CompactLogger) acquireEntry() *types.Entry {
 }
 
 func (l *CompactLogger) releaseEntry(entry *types.Entry) {
+	entry.Caller = 0
 	entry.Fields = nil
 	entry.Message = ""
 	entry.Properties = nil
@@ -199,6 +200,7 @@ func (l *CompactLogger) acquireZapEntry() *zapcore.Entry {
 func (l *CompactLogger) releaseZapEntry(entry *zapcore.Entry) {
 	entry.Message = ""
 	entry.Stack = ""
+	entry.Caller.Defined = false
 	l.zapEntryPool.Put(entry)
 }
 


### PR DESCRIPTION
Because of performance reasons we re-use memory in the `zap` adapter implementation, and on top of that we do not reset all fields, but only the bare minimum (to save CPU cycles). Because of that we forgot to clear field `Caller`. As result the caller line is always the same in the logs :(

Fixing it.