### PR TITLE
bugfix(zap): Do not panic, when an Entry used field Fields

### DIFF
--- a/tool/logger/implementation/zap/logger.go
+++ b/tool/logger/implementation/zap/logger.go
@@ -108,7 +108,7 @@ func (l Emitter) Emit(entry *types.Entry) {
 	}
 
 	var zapFields []zap.Field
-	if !entry.Properties.Has(EntryPropertyIgnoreFields) {
+	if !entry.Properties.Has(EntryPropertyIgnoreFields) && entry.Fields != nil {
 		zapFieldsPtr := fieldsToZap(entry.Fields.Len(), entry.Fields.ForEachField)
 		if zapFieldsPtr != nil {
 			defer releaseZapFields(zapFieldsPtr)


### PR DESCRIPTION
This case wasn't noticed before, because we always have some fields to log (for example the pid of the process).