### PR TITLE
linter: Ignore unused entryPropertyEnum and fieldProperty

### DIFF
--- a/tool/experimental/errmon/types/field_property.go
+++ b/tool/experimental/errmon/types/field_property.go
@@ -12,6 +12,7 @@
 
 package types
 
+//nolint:unused
 type fieldProperty uint
 
 const (

--- a/tool/logger/experimental/entry_property.go
+++ b/tool/logger/experimental/entry_property.go
@@ -12,6 +12,7 @@
 
 package experimental
 
+//nolint:unused
 type entryPropertyEnum uint
 
 const (


### PR DESCRIPTION
They are actually used, this seems like a false error. In the same very files these types are used to define public constants (which are then used in other packages).