### PR TITLE
bugfix(logrus-adapter): Fix reporting Caller

### DIFF
--- a/tool/logger/implementation/logrus/logger.go
+++ b/tool/logger/implementation/logrus/logger.go
@@ -67,10 +67,15 @@ func (l *Emitter) Emit(entry *types.Entry) {
 	l.logEntry(entry)
 }
 
+func ptr[T any](in T) *T {
+	return &in
+}
+
 func (l *Emitter) logEntry(entry *types.Entry) {
 	logrusLevel := LevelToLogrus(entry.Level)
-	logrusEntry := *l.LogrusEntry
+	logrusEntry := ptr(*l.LogrusEntry) // shallow copy
 	logrusEntry.Level = logrusLevel
+	logrusEntry.Caller = nil
 	if entry.Caller.Defined() {
 		caller := &runtime.Frame{
 			PC:   uintptr(entry.Caller),
@@ -79,42 +84,72 @@ func (l *Emitter) logEntry(entry *types.Entry) {
 		caller.Function = caller.Func.Name()
 		caller.File, caller.Line = entry.Caller.FileLine()
 		caller.Entry = entry.Caller.Entry()
+
+		// this is effectively a no-op line, see RestoreCallerHook's description:
 		logrusEntry.Caller = caller
-	} else {
-		logrusEntry.Caller = nil
+		// the actualizator-line:
+		logrusEntry.Context = context.WithValue(
+			context.Background(), LogrusCtxKeyCaller, caller,
+		)
 	}
 	logrusEntry.Time = entry.Timestamp
 	if !entry.Properties.Has(EntryPropertyIgnoreFields) {
-		if newFields := entry.Fields.Len(); newFields > 0 {
-			fields := make(logrus.Fields, len(logrusEntry.Data)+newFields)
+		newFieldsCount := 0
+		if entry.Fields != nil {
+			newFieldsCount = entry.Fields.Len()
+		}
+		if newFieldsCount > 0 || entry.TraceIDs != nil {
+			fields := make(logrus.Fields, len(logrusEntry.Data)+newFieldsCount+1)
 			for k, v := range logrusEntry.Data {
 				fields[k] = v
 			}
-			entry.Fields.ForEachField(func(f *field.Field) bool {
-				fields[f.Key] = f.Value
-				return true
-			})
+			if entry.Fields != nil {
+				entry.Fields.ForEachField(func(f *field.Field) bool {
+					fields[f.Key] = f.Value
+					return true
+				})
+			}
 			logrusEntry.Data = fields
+			if entry.TraceIDs != nil {
+				logrusEntry.Data[FieldNameTraceIDs] = entry.TraceIDs
+			}
 		}
-	}
-	if entry.TraceIDs != nil {
-		logrusEntry.Data[FieldNameTraceIDs] = entry.TraceIDs
 	}
 	logrusEntry.Log(logrusLevel, entry.Message)
 }
 
 // NewEmitter returns a new types.Emitter implementation based on a logrus logger.
-func NewEmitter(logger *logrus.Logger) *Emitter {
-	logrusEntry := logger.WithContext(context.Background())
-
+// This functions takes ownership of the logrus Logger instance.
+func NewEmitter(logger *logrus.Logger, logLevel logger.Level) *Emitter {
 	// Enforcing Trace level, because we will take care of logging levels ourselves.
 	//
 	// This is required, because logrus does not support contextual logging levels,
-	// so we handle them manually to enable such feature.
-	logrusEntry.Level = logrus.TraceLevel
+	// so we handle them manually to provide with this feature.
+	logger.Level = logrus.TraceLevel
 
+	// Logrus internally duplicates Entry and does not copy the Caller, so
+	// to keep the Caller we implement a workaround hook, which manually restores
+	// it.
+	//
+	// Note:
+	// The problem is there with any ReportCaller value, because with
+	// ReportCaller disabled the Caller is just set to nil, but will
+	// ReportCaller enabled it overwrites Caller using logrus's internal logic.
+	// So either it is required to hack-around each Formatter or to use a Hook,
+	// or to call `write` method manually (which is extra unsafety).
+	logger.Hooks.Add(newRestoreCallerHook())
+	logger.ReportCaller = false
+
+	logrusEntry := newLogrusEntry(logger, LevelToLogrus(logLevel))
 	return &Emitter{
 		LogrusEntry: logrusEntry,
+	}
+}
+
+func newLogrusEntry(logrusLogger *logrus.Logger, level logrus.Level) *logrus.Entry {
+	return &logrus.Entry{
+		Logger: logrusLogger,
+		Level:  level,
 	}
 }
 
@@ -134,13 +169,6 @@ type CompactLogger struct {
 	emitter            *Emitter
 	contextFields      *field.FieldsChain
 	prepareEmitterOnce sync.Once
-}
-
-func newLogrusEntry(logrusLogger *logrus.Logger, level logrus.Level) *logrus.Entry {
-	return &logrus.Entry{
-		Logger: logrusLogger,
-		Level:  level,
-	}
 }
 
 var _ adapter.CompactLogger = (*CompactLogger)(nil)
@@ -164,6 +192,7 @@ func (l *CompactLogger) acquireEntry() *types.Entry {
 }
 
 func (l *CompactLogger) releaseEntry(entry *types.Entry) {
+	entry.Caller = 0
 	entry.Fields = nil
 	entry.Message = ""
 	entry.Properties = nil
@@ -405,12 +434,10 @@ func (l *CompactLogger) Emitter() types.Emitter {
 	return l.emitter
 }
 
-func newCompactLoggerFromLogrus(logrusLogger *logrus.Logger, level logrus.Level, opts ...types.Option) *CompactLogger {
+func newCompactLoggerFromLogrus(logrusLogger *logrus.Logger, level logger.Level, opts ...types.Option) *CompactLogger {
 	cfg := types.Options(opts).Config()
 	return &CompactLogger{
-		emitter: &Emitter{
-			LogrusEntry: newLogrusEntry(logrusLogger, level),
-		},
+		emitter: NewEmitter(logrusLogger, level),
 		mostlyPersistentData: &mostlyPersistentData{
 			getCallerFunc: cfg.GetCallerFunc,
 			fmtBufPool: &sync.Pool{
@@ -428,17 +455,11 @@ func newCompactLoggerFromLogrus(logrusLogger *logrus.Logger, level logrus.Level,
 }
 
 // New returns a types.Logger implementation based on a logrus Logger.
+//
+// This function takes ownership of the logger instance.
 func New(logger *logrus.Logger, opts ...types.Option) types.Logger {
-	origLevel := logger.Level
-
-	// Enforcing Trace level, because we will take care of logging levels ourselves.
-	//
-	// This is required, because logrus does not support contextual logging levels,
-	// so we handle them manually to enable such feature.
-	logger.Level = logrus.TraceLevel
-
 	return adapter.GenericSugar{
-		CompactLogger: newCompactLoggerFromLogrus(logger, origLevel, opts...),
+		CompactLogger: newCompactLoggerFromLogrus(logger, LevelFromLogrus(logger.Level), opts...),
 	}
 }
 
@@ -451,17 +472,11 @@ func New(logger *logrus.Logger, opts ...types.Option) types.Logger {
 // Do not override this anywhere but in the `main` package.
 var DefaultLogrusLogger = func() *logrus.Logger {
 	l := logrus.New()
-	l.Formatter = &TextFormatter{
+	l.Formatter = &logrus.TextFormatter{
 		CallerPrettyfier: func(caller *runtime.Frame) (string, string) {
 			return "", fmt.Sprintf("%s:%d", filepath.Base(caller.File), caller.Line)
 		},
 	}
-
-	// Enforcing Trace level, because we will take care of logging levels ourselves.
-	//
-	// This is required, because logrus does not support contextual logging levels,
-	// so we handle them manually to enable such feature.
-	l.Level = logrus.TraceLevel
 	return l
 }
 

--- a/tool/logger/implementation/logrus/restore_caller_hook.go
+++ b/tool/logger/implementation/logrus/restore_caller_hook.go
@@ -13,15 +13,50 @@
 package logrus
 
 import (
+	"runtime"
+
 	"github.com/sirupsen/logrus"
 )
 
-// TextFormatter is a standard logrus.TextFormatter, but with
-// enabled printing of the caller if it is defined.
-type TextFormatter logrus.TextFormatter
+type logrusCtxKeyCallerT struct{}
 
-// Format implements logrus.Formatter.
-func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+var LogrusCtxKeyCaller = logrusCtxKeyCallerT{}
+
+// RestoreCallerHook is a logrus.Hook which sets the Caller
+// from a Context.
+type RestoreCallerHook struct{}
+
+var _ logrus.Hook = (*RestoreCallerHook)(nil)
+
+func newRestoreCallerHook() RestoreCallerHook {
+	return RestoreCallerHook{}
+}
+
+func (RestoreCallerHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+func (RestoreCallerHook) Fire(entry *logrus.Entry) error {
+	if entry.Context == nil {
+		// It looks like the Hook was used not through the logrus adapter,
+		// but directly by calling logrus logger itself. In this case
+		// we should not do anything.
+		//
+		// This can happen if one creates a logrus adapter providing a logrus Logger
+		// which is also used somewhere outside of this logrus adapter. This is supposed
+		// to be forbidden (see the description of function `New`), but better to
+		// add a bit of defensive code and avoid panics:
+		return nil
+	}
+
+	// restoring the Caller:
+	caller := entry.Context.Value(LogrusCtxKeyCaller)
+	if caller == nil {
+		// no Caller was set
+		return nil
+	}
+	entry.Caller, _ = caller.(*runtime.Frame)
+
+	// working around the check in standard formatters:
 	origLogger := entry.Logger
 	entry.Logger = &logrus.Logger{
 		Out:          origLogger.Out,
@@ -30,9 +65,8 @@ func (f *TextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		ReportCaller: true,
 		Level:        origLogger.Level,
 		ExitFunc:     origLogger.ExitFunc,
+		BufferPool:   origLogger.BufferPool,
 	}
-	defer func() {
-		entry.Logger = origLogger
-	}()
-	return (*logrus.TextFormatter)(f).Format(entry)
+
+	return nil
 }


### PR DESCRIPTION
The problem is:

`logrus` has absolutely no legit way to control `Caller` from outside. It overwrites the value no matter what. But `go-belt` controls `Caller` by itself (and reuses it across all tools, and allows to filter out extra entries).

Here I make a dirty hack to force logrus to use `Caller` value we set from the outside. This is achieved by adding a logrus `Hook` which sets the `Caller` after its value is reset by logrus. It also allowed me to delete older workaround-formatters which were solving the same problem but specifically for two formatters.

---

`git` thinks I renamed a file:
```
...r/implementation/logrus/text_formatter.go → ...lementation/logrus/restore_caller_hook.go
```
This is wrong. File `text_formatter.go` (and `json_formatter.go`) are deleted, and file `restore_caller_hook.go` is written from scratch. Looking at difference between `text_formatter.go` and `restore_caller_hook.go` does not make any sense.