### PR TITLE
[logger] Add method WithEntryProperties

### DIFF
--- a/tool/logger/adapter/compact_logger.go
+++ b/tool/logger/adapter/compact_logger.go
@@ -128,4 +128,8 @@ type CompactLogger interface {
 
 	// WithMessagePrefix adds a string to all messages logged through the derived logger
 	WithMessagePrefix(prefix string) CompactLogger
+
+	// WithEntryProperties adds props to EntryProperties of each emitted Entry.
+	// This could be used only for enabling implementation-specific behavior.
+	WithEntryProperties(props ...types.EntryProperty) CompactLogger
 }

--- a/tool/logger/adapter/generic_sugar.go
+++ b/tool/logger/adapter/generic_sugar.go
@@ -102,6 +102,11 @@ func (l GenericSugar) WithMessagePrefix(prefix string) types.Logger {
 	return GenericSugar{CompactLogger: l.CompactLogger.WithMessagePrefix(prefix)}
 }
 
+// WithMessagePrefix implements logger.Logger.
+func (l GenericSugar) WithEntryProperties(props ...types.EntryProperty) types.Logger {
+	return GenericSugar{CompactLogger: l.CompactLogger.WithEntryProperties(props...)}
+}
+
 // TraceFields implements logger.Logger.
 func (l GenericSugar) TraceFields(message string, fields field.AbstractFields) {
 	l.LogFields(types.LevelTrace, message, fields)

--- a/tool/logger/types/entry.go
+++ b/tool/logger/types/entry.go
@@ -62,7 +62,7 @@ type Entry struct {
 // Any Emitter implementation, Hook or other tool may use it
 // for internal or/and external needs.
 //
-// For example, a Backlogger may support both async and sync logging,
+// For example, a Emitter may support both async and sync logging,
 // and it could be possible to request sync logging through a property.
 //
 // Another example is: if an error monitor and a logger are hooked to each
@@ -77,9 +77,31 @@ type EntryProperties []EntryProperty
 // It should be equal by both: type and value.
 func (s EntryProperties) Has(p EntryProperty) bool {
 	for _, cmp := range s {
+		if l, ok := cmp.(EntryProperties); ok {
+			if l.Has(p) {
+				return true
+			}
+			continue
+		}
 		if cmp == p {
 			return true
 		}
 	}
 	return false
+}
+
+// Add returns the concatenation of EntryProperties.
+//
+// Note! It does not work similar to classical `append` function,
+// instead it nests two slices into a new slice to optimize for CPU and RAM
+// (by avoiding extra memory allocation and copying).
+func (s EntryProperties) Add(a ...EntryProperty) EntryProperties {
+	switch {
+	case len(s) == 0:
+		return a
+	case len(a) == 0:
+		return s
+	default:
+		return EntryProperties{EntryProperties(s), EntryProperties(a)}
+	}
 }

--- a/tool/logger/types/entry_test.go
+++ b/tool/logger/types/entry_test.go
@@ -1,0 +1,32 @@
+// Copyright 2023 Meta Platforms, Inc. and affiliates.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type dummyProp struct{}
+
+func TestEntryPropertiesAppend(t *testing.T) {
+	s0 := EntryProperties{1, "a"}
+	s1 := EntryProperties{"b", dummyProp{}}
+	require.True(t, s1.Has(dummyProp{}))
+
+	r := s0.Add(s1)
+
+	require.True(t, r.Has(dummyProp{}))
+	require.True(t, !r.Has(1.5))
+}

--- a/tool/logger/types/logger.go
+++ b/tool/logger/types/logger.go
@@ -216,6 +216,10 @@ type Logger interface {
 
 	// WithMessagePrefix adds a string to all messages logged through the derived logger.
 	WithMessagePrefix(prefix string) Logger
+
+	// WithEntryProperties adds props to EntryProperties of each emitted Entry.
+	// This could be used only for enabling implementation-specific behavior.
+	WithEntryProperties(props ...EntryProperty) Logger
 }
 
 // Emitter is a log entry sender. It is not obligated to provide


### PR DESCRIPTION
There is an use case, where it is required to tag a specific log entry for post-processing by hooks. The problem is to make a hook to differentiate an entry to process and an entry not to process. And it is required to avoid initializing a hook late (while already sending a debug message), and it is required to avoid by-string-comparison in the hook. We already had by design a thing to handle such things, it was called `EntryProperties`. Up until now it was used only internally (despite being a public entity), and apparently I forgot to add a method, which would control `EntryProperties` from the outside. Fixing it.