### PR TITLE
bugfix(logger): Fix WithMessagePrefix in adapters for logrus and zap

### DIFF
--- a/tool/logger/implementation/logrus/logger.go
+++ b/tool/logger/implementation/logrus/logger.go
@@ -190,6 +190,9 @@ func (l *CompactLogger) LogEntry(entry *types.Entry) {
 	l.logEntry(entry)
 }
 func (l *CompactLogger) logEntry(entry *types.Entry) {
+	if l.messagePrefix != "" {
+		entry.Message = l.messagePrefix + entry.Message
+	}
 	if !entry.Caller.Defined() && l.getCallerFunc != nil {
 		entry.Caller = l.getCallerFunc()
 	}

--- a/tool/logger/tests/implementation_test.go
+++ b/tool/logger/tests/implementation_test.go
@@ -157,6 +157,16 @@ func TestImplementations(t *testing.T) {
 					t.Fatalf("logger %s did not print an error using Error with the PreHook", l.Name)
 				}
 			})
+
+			t.Run("WithMessagePrefix", func(t *testing.T) {
+				l.Output.Reset()
+				logger := l.Logger.WithMessagePrefix("specialMagic")
+				logger.Error(fmt.Errorf("unit-test"))
+				logger.Flush()
+				if !strings.Contains(l.Output.String(), "specialMagic") {
+					t.Fatalf("logger %s did not print the special magic string", l.Name)
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
Apparently this method wasn't working for logrus and zap (it was never used before, and wasn't noticed). Added an unit-test and a fix.