### PR TITLE
add context into interface

### DIFF
--- a/belt.go
+++ b/belt.go
@@ -13,6 +13,7 @@
 package belt
 
 import (
+	"context"
 	"sync"
 
 	"github.com/facebookincubator/go-belt/pkg/field"
@@ -196,8 +197,15 @@ func (belt *Belt) TraceIDs() TraceIDs {
 }
 
 // Flush forces to flush all buffers of all the tools.
-func (belt *Belt) Flush() {
-	for _, tool := range belt.Tools() {
-		tool.Flush()
-	}
+func (belt *Belt) Flush(ctx context.Context) {
+	ctx, cancelFn := context.WithCancel(ctx)
+
+	go func(){
+		for _, tool := range belt.Tools() {
+			tool.Flush(ctx)
+		}
+		cancelFn()
+	}()
+
+	<-ctx.Done()
 }

--- a/belt_test.go
+++ b/belt_test.go
@@ -13,6 +13,7 @@
 package belt
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -24,7 +25,7 @@ type dummyTool struct{}
 
 var _ Tool = (*dummyTool)(nil)
 
-func (dummyTool) Flush() {}
+func (dummyTool) Flush(context.Context) {}
 func (dummyTool) WithContextFields(allFields *field.FieldsChain, newFieldsCount int) Tool {
 	return dummyTool{}
 }

--- a/beltctx/context.go
+++ b/beltctx/context.go
@@ -133,5 +133,5 @@ func Tools(ctx context.Context) belt.Tools {
 //
 // Deprecated: use belt.Flush, instead.
 func Flush(ctx context.Context) {
-	Belt(ctx).Flush()
+	Belt(ctx).Flush(ctx)
 }

--- a/context.go
+++ b/context.go
@@ -106,5 +106,5 @@ func GetTools(ctx context.Context) Tools {
 
 // CtxFlush forces to flush all buffers of all the tools.
 func Flush(ctx context.Context) {
-	CtxBelt(ctx).Flush()
+	CtxBelt(ctx).Flush(ctx)
 }

--- a/tool.go
+++ b/tool.go
@@ -13,13 +13,15 @@
 package belt
 
 import (
+	"context"
+
 	"github.com/facebookincubator/go-belt/pkg/field"
 )
 
 // Tool is an abstract observability tool. It could be a Logger, metrics, tracing or anything else.
 type Tool interface {
 	// Flush forces to flush all buffers.
-	Flush()
+	Flush(ctx context.Context)
 
 	// WithContextFields sets new context-defined fields. Supposed to be called
 	// only by an Belt.

--- a/tool/experimental/errmon/adapter/generic_error_monitor.go
+++ b/tool/experimental/errmon/adapter/generic_error_monitor.go
@@ -13,6 +13,7 @@
 package adapter
 
 import (
+	"context"
 	"time"
 
 	"github.com/facebookincubator/go-belt"
@@ -170,4 +171,4 @@ func (h *GenericErrorMonitor) WithTraceIDs(allTraceIDs TraceIDs, _ int) belt.Too
 }
 
 // Flush implements metrics.Metrics (or more specifically belt.Tool).
-func (*GenericErrorMonitor) Flush() {}
+func (*GenericErrorMonitor) Flush(context.Context) {}

--- a/tool/experimental/metrics/implementation/dummy/dummy_metrics.go
+++ b/tool/experimental/metrics/implementation/dummy/dummy_metrics.go
@@ -13,6 +13,8 @@
 package dummy
 
 import (
+	"context"
+
 	"github.com/facebookincubator/go-belt"
 	"github.com/facebookincubator/go-belt/pkg/field"
 	metrics "github.com/facebookincubator/go-belt/tool/experimental/metrics/types"
@@ -70,7 +72,7 @@ func (*Metrics) CountFields(key string, additionalFields field.AbstractFields) m
 }
 
 // Flush implements metrics.Metrics.
-func (*Metrics) Flush() {}
+func (*Metrics) Flush(context.Context) {}
 
 type gauge struct{}
 

--- a/tool/experimental/metrics/implementation/prometheus/metrics.go
+++ b/tool/experimental/metrics/implementation/prometheus/metrics.go
@@ -18,6 +18,7 @@
 package prometheus
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -577,7 +578,7 @@ func (m *Metrics) WithTraceIDs(traceIDs belt.TraceIDs, newTraceIDsCount int) bel
 }
 
 // Flush implements metrics.Metrics (or more specifically belt.Tool).
-func (*Metrics) Flush() {}
+func (*Metrics) Flush(context.Context) {}
 
 func fieldsToLabels(fields field.AbstractFields) prometheus.Labels {
 	labels := make(prometheus.Labels, fields.Len())

--- a/tool/experimental/metrics/implementation/simplemetrics/metrics.go
+++ b/tool/experimental/metrics/implementation/simplemetrics/metrics.go
@@ -18,6 +18,7 @@
 package simplemetrics
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -219,4 +220,4 @@ func (metrics *Metrics) WithTraceIDs(traceIDs TraceIDs, newTraceIDsCount int) To
 }
 
 // Flush implements metrics.Metrics (or more specifically belt.Tool).
-func (*Metrics) Flush() {}
+func (*Metrics) Flush(context.Context) {}

--- a/tool/experimental/metrics/implementation/tsmetrics/metrics.go
+++ b/tool/experimental/metrics/implementation/tsmetrics/metrics.go
@@ -18,6 +18,8 @@
 package tsmetrics
 
 import (
+	"context"
+
 	"github.com/facebookincubator/go-belt/tool/experimental/metrics/types"
 	tsmetrics "github.com/xaionaro-go/metrics"
 )
@@ -180,4 +182,4 @@ func (m *Metrics) WithTraceIDs(traceIDs TraceIDs, newTraceIDsCount int) Tool {
 }
 
 // Flush implements metrics.Metrics (or more specifically belt.Tool).
-func (*Metrics) Flush() {}
+func (*Metrics) Flush(context.Context) {}

--- a/tool/experimental/tracer/implementation/logger/span.go
+++ b/tool/experimental/tracer/implementation/logger/span.go
@@ -157,5 +157,5 @@ func (span *SpanImpl) FinishWithDuration(duration time.Duration) {
 
 // Flush implements tracer.Span
 func (span *SpanImpl) Flush() {
-	span.Tracer.Flush()
+	span.Tracer.Flush(context.TODO())
 }

--- a/tool/experimental/tracer/implementation/logger/tracer.go
+++ b/tool/experimental/tracer/implementation/logger/tracer.go
@@ -105,8 +105,8 @@ func (t *TracerImpl) StartChildWithCtx(ctx context.Context, name string, options
 }
 
 // Flush implements tracer.Tracer.
-func (t *TracerImpl) Flush() {
-	t.Logger.Flush()
+func (t *TracerImpl) Flush(ctx context.Context) {
+	t.Logger.Flush(ctx)
 }
 
 func (t *TracerImpl) send(span *SpanImpl) {

--- a/tool/experimental/tracer/implementation/zipkin/tracer.go
+++ b/tool/experimental/tracer/implementation/zipkin/tracer.go
@@ -131,7 +131,7 @@ func (t *TracerImpl) WithHooks(hooks ...tracer.Hook) tracer.Tracer {
 }
 
 // Flush implements tracer.Tracer.
-func (t *TracerImpl) Flush() {
+func (t *TracerImpl) Flush(context.Context) {
 	panic("not supported")
 }
 

--- a/tool/experimental/tracer/noop_tracer.go
+++ b/tool/experimental/tracer/noop_tracer.go
@@ -74,4 +74,4 @@ func (t noopTracer) WithHooks(...Hook) Tracer {
 }
 
 // Flush implements Tracer.
-func (noopTracer) Flush() {}
+func (noopTracer) Flush(context.Context) {}

--- a/tool/logger/adapter/generic_logger.go
+++ b/tool/logger/adapter/generic_logger.go
@@ -13,6 +13,7 @@
 package adapter
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -359,7 +360,7 @@ func (l *GenericLogger) emit(entry *types.Entry) {
 
 	switch entry.Level {
 	case types.LevelPanic, types.LevelFatal:
-		l.Flush()
+		l.Flush(context.TODO())
 		switch entry.Level {
 		case types.LevelPanic:
 			panic(fmt.Sprintf("panic was requested with the log entry: %#v", entry))
@@ -370,7 +371,7 @@ func (l *GenericLogger) emit(entry *types.Entry) {
 }
 
 // Flush implements types.CompactLogger.
-func (l *GenericLogger) Flush() {
+func (l *GenericLogger) Flush(context.Context) {
 	l.Emitters.Flush()
 }
 

--- a/tool/logger/adapter/generic_sugar.go
+++ b/tool/logger/adapter/generic_sugar.go
@@ -13,6 +13,8 @@
 package adapter
 
 import (
+	"context"
+
 	"github.com/facebookincubator/go-belt"
 	"github.com/facebookincubator/go-belt/pkg/field"
 	"github.com/facebookincubator/go-belt/tool/logger/types"
@@ -49,8 +51,8 @@ func (l GenericSugar) Logf(level types.Level, format string, args ...any) {
 }
 
 // Flush implements logger.Logger.
-func (l GenericSugar) Flush() {
-	l.CompactLogger.Flush()
+func (l GenericSugar) Flush(ctx context.Context) {
+	l.CompactLogger.Flush(ctx)
 }
 
 // Emitter implements logger.Logger.

--- a/tool/logger/ctx.go
+++ b/tool/logger/ctx.go
@@ -32,7 +32,7 @@ func CtxWithLogger(ctx context.Context, logger Logger) context.Context {
 
 // Flush forces to flush all buffers.
 func Flush(ctx context.Context) {
-	FromCtx(ctx).Flush()
+	FromCtx(ctx).Flush(ctx)
 }
 
 // WithContextFields is a shorthand for FromCtx(ctx).WithContextFields

--- a/tool/logger/implementation/logrus/logger.go
+++ b/tool/logger/implementation/logrus/logger.go
@@ -187,7 +187,7 @@ type CompactLogger struct {
 var _ adapter.CompactLogger = (*CompactLogger)(nil)
 
 // Flush implements types.CompactLogger
-func (l *CompactLogger) Flush() {
+func (l *CompactLogger) Flush(context.Context) {
 	l.emitter.Flush()
 	for _, hook := range l.hooks {
 		hook.Flush()

--- a/tool/logger/implementation/zap/logger.go
+++ b/tool/logger/implementation/zap/logger.go
@@ -18,6 +18,7 @@
 package zap
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -174,7 +175,7 @@ type CompactLogger struct {
 var _ adapter.CompactLogger = (*CompactLogger)(nil)
 
 // Flush implements types.CompactLogger.
-func (l *CompactLogger) Flush() {
+func (l *CompactLogger) Flush(context.Context) {
 	l.emitter.Flush()
 	for _, hook := range l.hooks {
 		hook.Flush()

--- a/tool/logger/tests/implementation_test.go
+++ b/tool/logger/tests/implementation_test.go
@@ -14,6 +14,7 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"net/url"
@@ -127,13 +128,13 @@ func TestImplementations(t *testing.T) {
 					l.Logger.Errorf("test1")
 				}()
 				wg.Wait()
-				l.Logger.Flush()
+				l.Logger.Flush(context.TODO())
 			})
 
 			t.Run("Errorf", func(t *testing.T) {
 				l.Output.Reset()
 				l.Logger.Errorf("unit-test")
-				l.Logger.Flush()
+				l.Logger.Flush(context.TODO())
 				if !strings.Contains(l.Output.String(), "unit-test") {
 					t.Fatalf("logger %s did not print an error using Errorf", l.Name)
 				}
@@ -142,7 +143,7 @@ func TestImplementations(t *testing.T) {
 			t.Run("Error", func(t *testing.T) {
 				l.Output.Reset()
 				l.Logger.Error(fmt.Errorf("unit-test"))
-				l.Logger.Flush()
+				l.Logger.Flush(context.TODO())
 				if !strings.Contains(l.Output.String(), "unit-test") {
 					t.Fatalf("logger %s did not print an error using Error", l.Name)
 				}
@@ -152,7 +153,7 @@ func TestImplementations(t *testing.T) {
 				l.Output.Reset()
 				logger := l.Logger.WithPreHooks(addExtraFieldPreHook{})
 				logger.Error(fmt.Errorf("unit-test"))
-				logger.Flush()
+				logger.Flush(context.TODO())
 				if !strings.Contains(l.Output.String(), "unit-test") {
 					t.Fatalf("logger %s did not print an error using Error with the PreHook", l.Name)
 				}
@@ -162,7 +163,7 @@ func TestImplementations(t *testing.T) {
 				l.Output.Reset()
 				logger := l.Logger.WithMessagePrefix("specialMagic")
 				logger.Error(fmt.Errorf("unit-test"))
-				logger.Flush()
+				logger.Flush(context.TODO())
 				if !strings.Contains(l.Output.String(), "specialMagic") {
 					t.Fatalf("logger %s did not print the special magic string", l.Name)
 				}


### PR DESCRIPTION
Add context() into interface, so that we can timeout / cancel the function call.

Tried `go test ./...` to make sure no test failing.